### PR TITLE
Improved search bar

### DIFF
--- a/src/tui/tabs/home.cpp
+++ b/src/tui/tabs/home.cpp
@@ -4,7 +4,7 @@ void tui::home::draw() {
   video_tab::draw();
 }
 
-void tui::home::process_input(char input) {
+void tui::home::process_input(int input) {
  video_tab::process_input(input) ;
 }
 

--- a/src/tui/tabs/home.hpp
+++ b/src/tui/tabs/home.hpp
@@ -7,7 +7,7 @@ namespace tui {
   class home : public video_tab {
   public:
     void draw() override;
-    void process_input(char input) override;
+    void process_input(int input);
 
     std::string get_title() override;
 

--- a/src/tui/tabs/related.cpp
+++ b/src/tui/tabs/related.cpp
@@ -1,0 +1,21 @@
+#include "related.hpp"
+
+void tui::related::draw() {
+  video_tab::draw();
+}
+
+void tui::related::process_input(int input) {
+	if(input == 'c'){
+		//close tab
+	}else{
+		video_tab::process_input(input) ;
+	}
+}
+
+std::string tui::related::get_title() {
+ return m_refreshing ? "related videos - refreshing" : video_url; 
+}
+
+std::string tui::related::get_source_url() {
+ return video_url; 
+}

--- a/src/tui/tabs/related.hpp
+++ b/src/tui/tabs/related.hpp
@@ -2,10 +2,9 @@
 #define _TABS_SEARCH_H_
 
 #include "video_tab.hpp"
-#include "../tui.hpp"
 
 namespace tui {
-  class search : public video_tab {
+  class related : public video_tab {
   public:
     void draw() override;
     void process_input(int input);
@@ -13,10 +12,7 @@ namespace tui {
     std::string get_title() override;
     std::string get_source_url() override;
 
-  private:
-    bool m_in_results_view = false;
-    std::string m_search_text = "";
-    std::string m_search_text_previous = "";
+    std::string video_url = "";
   };
 } // namespace tui
 

--- a/src/tui/tabs/search.cpp
+++ b/src/tui/tabs/search.cpp
@@ -19,39 +19,57 @@ void tui::search::draw() {
     utils::move_cursor((terminal_width - search_width) * .5f,
                        terminal_height * .5f);
 
-    std::string search_box = "[" + m_search_text;
+    std::string search_box = "[" + m_search_text + "_";
     search_box.resize(search_width - 1, ' ');
     search_box += ']';
 
     printf("%s", search_box.c_str());
+   
   }
 }
 
-void tui::search::process_input(char input) {
+void tui::search::process_input(int input) {
   if (m_in_results_view) {
-    if (input == 'b') {
+    if (input == -'b') {
       m_in_results_view = false;
     }
 
     else {
-      video_tab::process_input(input);
+	  video_tab::process_input(input);
     }
   }
 
   else {
+    setESC(false);
     if (input == 0xA) {
-      m_in_results_view = true;
-      utils::clear(true);
+    	m_in_results_view = true;
+	utils::clear(true);
+	setESC(true);
+	m_search_text_previous = m_search_text;
+	video_tab::refresh();
     }
-
-    else {
-      m_search_text += input;
+    else if (input == 127){
+    	if(!m_search_text.length()){
+		setESC(true);
+		if(!m_search_text_previous.length()){
+			moveTab(-1);
+		}else{
+    			m_in_results_view = true;
+			utils::clear(true);
+			m_search_text = m_search_text_previous;
+		}
+	}else if(m_search_text.length() > 0){
+		m_search_text.pop_back();	
+	}
+    }
+    else if (input > 31){
+    	m_search_text += input;
     }
   }
 }
 
 std::string tui::search::get_title() {
-  return m_refreshing ? "search - refreshing" : "search";
+  return m_refreshing ? "search - refreshing" : "search: "+m_search_text;
 }
 
 std::string tui::search::get_source_url() {

--- a/src/tui/tabs/tab.cpp
+++ b/src/tui/tabs/tab.cpp
@@ -1,4 +1,5 @@
 #include "tab.hpp"
+#include "../tui.hpp"
 #include "../utils.hpp"
 
 void tui::tab::draw() {
@@ -15,14 +16,15 @@ void tui::tab::draw() {
                         utils::color::white, utils::color::black);
     }
   }
+
 }
 
 std::string tui::tab::get_title() {
   return "default title";
 }
 
-void tui::tab::process_input(char input) {
-  switch (input) {
+void tui::tab::process_input(int input) {
+  switch (-input) {
   case 'j':
     m_selected_item++;
     break;
@@ -39,7 +41,7 @@ void tui::tab::process_input(char input) {
 
   int terminal_height = utils::get_terminal_height();
 
-  int scroll_start;
+  int scroll_start=0;
 
   if (m_items.size() >= terminal_height - 2) {
     while (terminal_height - m_selected_item + m_scroll_offset <= 2) {

--- a/src/tui/tabs/tab.hpp
+++ b/src/tui/tabs/tab.hpp
@@ -22,7 +22,7 @@ namespace tui {
 
     virtual std::string get_title();
 
-    virtual void process_input(char input);
+    virtual void process_input(int input);
 
   protected:
     int m_scroll_offset = 0;

--- a/src/tui/tabs/video_tab.cpp
+++ b/src/tui/tabs/video_tab.cpp
@@ -13,15 +13,15 @@ void tui::video_tab::draw() {
   tab::draw();
 }
 
-void tui::video_tab::process_input(char input) {
-  switch (input) {
+void tui::video_tab::process_input(int input) {
+  switch (-input) {
   case 'r':
     refresh();
     break;
 
   case 0xA: // enter
-    system(("mpv \"https://www.youtube.com" + m_videos[m_selected_item].url +
-            "\" > /dev/null")
+    system(("nohup mpv \"https://www.youtube.com" + m_videos[m_selected_item].url +
+            "\" 2>&1 &")
                .c_str());
 
     // clear mpv text from the screen - force a redraw

--- a/src/tui/tabs/video_tab.hpp
+++ b/src/tui/tabs/video_tab.hpp
@@ -8,7 +8,7 @@ namespace tui {
   class video_tab : public tab {
   public:
     virtual void draw() override;
-    virtual void process_input(char input) override;
+    virtual void process_input(int input);
 
     virtual std::string get_title() override = 0;
 

--- a/src/tui/tui.hpp
+++ b/src/tui/tui.hpp
@@ -7,4 +7,7 @@ namespace tui {
   extern void run();
 }
 
+void setESC(bool input);
+void moveTab(int input);
+
 #endif


### PR DESCRIPTION
Good day. Very good program! The search bar was not working properly, for example, pressing 'q' would quit it, user was also unable to search more than once. 'h and 'l' are now used to move between tabs instead of tab, since implementing shift+tab to move to the left would require much more code. Also, now I'm calling mpv with nohup so there is no output in the terminal and it's completely independent process.